### PR TITLE
Fix if default encoding not 'UTF-8'

### DIFF
--- a/comicepub/render.py
+++ b/comicepub/render.py
@@ -4,7 +4,7 @@ from typing import List, Tuple, Set
 
 
 def get_content_from_file(path):
-    with open(os.path.join(os.path.dirname(__file__), path), 'r',encoding='UTF-8') as f:
+    with open(os.path.join(os.path.dirname(__file__), path), 'r', encoding='utf-8') as f:
         return f.read()
 
 

--- a/comicepub/render.py
+++ b/comicepub/render.py
@@ -4,7 +4,7 @@ from typing import List, Tuple, Set
 
 
 def get_content_from_file(path):
-    with open(os.path.join(os.path.dirname(__file__), path), 'r') as f:
+    with open(os.path.join(os.path.dirname(__file__), path), 'r',encoding='UTF-8') as f:
         return f.read()
 
 


### PR DESCRIPTION
fix this error
UnicodeDecodeError: 'gbk' codec can't decode byte 0x80 in position illegal multibyte sequence